### PR TITLE
Handle the case where "peers" vector is empty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ default-features=false
 version="1.0.0-rc"
 default-features=false
 
+[dependencies.actix-service]
+version = "0.4.0"
+
 [dependencies.tokio-tcp]
 version = "0.1.3"
 


### PR DESCRIPTION
This PR restores the original HyperG behaviour in tests / with multiple Golem instances on a single machine: if no peers were provided, the requested resources are expected to be available locally.

This PR mimics the download process by copying the already "downloaded" files. Mandatory for the full Golem test suite to pass.

